### PR TITLE
Add comma-dangle always-multiline rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,10 @@
     "indent": [
       "error",
       2
+    ],
+    "comma-dangle": [
+      "warn",
+      "always-multiline"
     ]
   },
   "parserOptions": {


### PR DESCRIPTION
Reduces diff size and chance of conflicts from commas:
https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8