### PR TITLE
Add indentation for switch body

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,10 @@
     "no-console": "warn",
     "indent": [
       "error",
-      2
+      2,
+      {
+        "SwitchCase": 1
+      }
     ],
     "comma-dangle": [
       "warn",


### PR DESCRIPTION
I find it easier to tell where the switch body ends when it is indented like this:
```
switch() {
  case 'condition':
    return true;
    break;
  default:
    return false;
}
```

vs unindented like this:
```
switch() {
case 'condition':
  return true;
  break;
default:
  return false;
}
```

But maybe there's a good reason not to indent the switch body?